### PR TITLE
Fix name in dev container configuration of python_typescript template

### DIFF
--- a/src/python_typescript/.devcontainer/devcontainer.json
+++ b/src/python_typescript/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"name": "Java & Typescript",
+	"name": "Python & Typescript",
 	"image": "mcr.microsoft.com/devcontainers/base:${templateOption:imageVariant}",
 
 	// 👇 Features to add to the Dev Container. More info: https://containers.dev/implementors/features.


### PR DESCRIPTION
It looks like the name was mistakenly copied and pasted from the `java_typescript` template.

The name is already correct on the `devcontainer-template.json` file.
