### PR TITLE
Fixed incorrect name of devcontainer

### DIFF
--- a/src/python_typescript/.devcontainer/devcontainer.json
+++ b/src/python_typescript/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-	"name": "Java & Typescript",
+	"name": "Python & Typescript",
 	"image": "mcr.microsoft.com/devcontainers/base:${templateOption:imageVariant}",
 
 	// 👇 Features to add to the Dev Container. More info: https://containers.dev/implementors/features.


### PR DESCRIPTION
## 📑 Description
Fixed incorrect name of devcontainer (Java & Typescript > Python & Typescript).

(I was just browsing devcontainer templates and found this small inconsistency). 

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [x] I have updated the documentation as required
- [x] All the tests have passed

## ℹ️ Additional Information

